### PR TITLE
Add Github Actions deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+# This is a basic workflow to help you get started with Actions
+
+name: deploy
+
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      AUTODEPLOY_TAG: ${{ secrets.AUTODEPLOY_TAG }}
+      AUTODEPLOY_URL: https://dfusion.auto.gnosisdev.com/services/dfusion-v2-optimizer-api-mainnet,dfusion-v2-optimizer-api-testnets/rollout
+      AUTODEPLOY_TOKEN: ${{ secrets.AUTODEPLOY_TOKEN }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      REGISTRY_URI: ${{ secrets.REGISTRY_URI }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - run: docker/deploy.sh ${GITHUB_REF#refs/*/}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+FROM rust:nightly-buster-slim as build
+
+# create a new empty shell project
+RUN USER=root cargo new --bin hdnode
+WORKDIR /hdnode
+
+# copy over your manifests
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./Cargo.toml ./Cargo.toml
+
+# this build step will cache your dependencies
+RUN cargo build --release
+RUN rm src/*.rs
+
+# copy your source tree
+COPY ./src ./src
+
+# build for release
+RUN rm ./target/release/deps/hdnode*
+RUN cargo build --release
+
+# our final base
+FROM rust:nightly-buster-slim
+
+# copy the build artifact from the build stage
+COPY --from=build /hdnode/target/release/hdnode .
+
+# set the startup command to run your binary
+CMD ["./hdnode"]

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -uo pipefail
+
+# Get login token and execute login
+sudo pip install awscli
+$(aws ecr get-login --no-include-email --region $AWS_REGION)
+
+echo "Tagging latest image with solver...";
+docker build --tag $REGISTRY_URI:$1 -f docker/Dockerfile .
+echo "Pushing image";
+docker push $REGISTRY_URI:$1


### PR DESCRIPTION
- Add deploy.yml workflow file with step to build an docker image from main branch or a tag release.
- Add docker/deploy.sh shell script to build and push a docker image from `docker/Dockerfile` file.
   
> Original PR https://github.com/gnosis/hdnode/pull/1 by @davidalbela