### PR TITLE
Autodeploy on main branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,9 +36,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - uses: cowprotocol/autodeploy@v1
+      - uses: cowprotocol/autodeploy-action@v1
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           pods: dfusion-v2-hdnode-mainnet,dfusion-v2-hdnode-rinkeby,dfusion-v2-hdnode-xdai
-          url: ${{ secret.AUTODEPLOY_URL }}
+          url: ${{ secrets.AUTODEPLOY_URL }}
           token: ${{ secrets.AUTODEPLOY_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: docker/login-action@v1
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,3 +35,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - uses: cowprotocol/autodeploy@v1
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          pods: dfusion-v2-hdnode-mainnet,dfusion-v2-hdnode-rinkeby,dfusion-v2-hdnode-xdai
+          url: ${{ secret.AUTODEPLOY_URL }}
+          token: ${{ secrets.AUTODEPLOY_TOKEN }}

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -9,7 +9,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
Supersedes #1 

This PR enables auto-deployment on changes to the `main` branch using a new deployment GitHub action.

@davidalbela can you configure the `AUTODEPLOY_TOKEN` authentication secret?


